### PR TITLE
fix(github actions): release-please, add permission for labels

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write # required for label creation
 
 jobs:
   release-please:


### PR DESCRIPTION
## what

- fix issue where release-release could not create labels ([example](https://github.com/masterpointio/terraform-postgres-automation/actions/runs/14671513148/job/41180498293)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to allow the workflow to create or modify issue labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->